### PR TITLE
[fix] 警告の回避 指定のフォルダが無いときの警告を対処

### DIFF
--- a/src/MainPane.tsx
+++ b/src/MainPane.tsx
@@ -19,6 +19,8 @@ import { basename, normalize } from '@tauri-apps/api/path';
 
 import { executeShellCommand } from './RustFuncs';
 
+ const dummy: never[] = [];
+ 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 export const MainPanel = (
   props: {
@@ -226,7 +228,7 @@ export const MainPanel = (
 
   const [fileList, FileListFunctions] = FileList(
     {
-      entries: entries ?? [],
+      entries: entries ?? dummy,
       initCurrentItemHint: initCurrentItemHint,
       onSelectItemNumChanged: props.onSelectItemNumChanged,
       accessParentDir: accessParentDir,


### PR DESCRIPTION
* オブジェクトが別の物になるため、無限ループが発生していた。